### PR TITLE
intake subsystem coast() function fix

### DIFF
--- a/src/main/java/frc/robot/commands/Rotate.java
+++ b/src/main/java/frc/robot/commands/Rotate.java
@@ -36,6 +36,6 @@ public class Rotate extends Command {
 
     @Override
     public boolean isFinished() {
-        return Math.abs(degrees - (driveBaseSubsystem.getYaw() + 320.4)) < 3;
+        return Math.abs(degrees - driveBaseSubsystem.getYaw()) < 3;
     }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -96,7 +96,7 @@ public class IntakeSubsystem extends SubsystemBase {
      */
     private void coast() {
         topMotor.setNeutralMode(NeutralModeValue.Coast);
-        topMotor.setNeutralMode(NeutralModeValue.Coast);
+        bottomMotor.setNeutralMode(NeutralModeValue.Coast);
     }
 
     /**


### PR DESCRIPTION
fixed a small bug with coast() function where top motor was coasted twice in coast function instead of top motor and bottom motor both being coasted.

removed random number from isFinished() in rotate